### PR TITLE
任意文字列でTodoの検索できる機能追加

### DIFF
--- a/api/src/application/task/get_task_usecase.go
+++ b/api/src/application/task/get_task_usecase.go
@@ -21,9 +21,10 @@ func NewGetTaskUseCase(
 }
 
 type GetTaskUseCaseInputDto struct {
-	Offset   int
-	PageSize int
-	Status   *string
+	Offset     int
+	PageSize   int
+	Status     *string
+	SearchWord *string
 }
 
 type GetTaskUseCaseOutputDto struct {
@@ -34,7 +35,7 @@ func (uc *GetTaskUseCase) Run(
 	ctx context.Context,
 	dto GetTaskUseCaseInputDto,
 ) (*GetTaskUseCaseOutputDto, error) {
-	tasks, err := uc.taskRepository.Get(ctx, dto.Offset, dto.PageSize, dto.Status)
+	tasks, err := uc.taskRepository.Get(ctx, dto.Offset, dto.PageSize, dto.Status, dto.SearchWord)
 	if err != nil {
 		logging.Logger.Error("サーバーエラー", "error", err)
 		return nil, err

--- a/api/src/application/task/get_task_usecase_test.go
+++ b/api/src/application/task/get_task_usecase_test.go
@@ -26,12 +26,13 @@ func TestGetTaskUseCase_Run(t *testing.T) {
 		{
 			name: "Todoを全件取得し、DTOを返却すること",
 			input: GetTaskUseCaseInputDto{
-				Offset:   100,
-				PageSize: 1,
-				Status:   strPtr("Pending"),
+				Offset:     100,
+				PageSize:   1,
+				Status:     strPtr("Pending"),
+				SearchWord: strPtr(""),
 			},
 			mockFunc: func() {
-				mockTaskRepo.EXPECT().Get(gomock.Any(), 100, 1, strPtr("Pending")).Return([]*taskDomain.Task{
+				mockTaskRepo.EXPECT().Get(gomock.Any(), 100, 1, strPtr("Pending"), strPtr("")).Return([]*taskDomain.Task{
 					{
 						Id:      "46039334-6ffc-4fe3-ab59-f40a7b73b611",
 						Title:   "Todoのテストを行う1",

--- a/api/src/domain/task/mock_task_repository.go
+++ b/api/src/domain/task/mock_task_repository.go
@@ -69,18 +69,18 @@ func (mr *MockTaskRepositoryMockRecorder) FindById(ctx, id any) *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockTaskRepository) Get(ctx context.Context, offset, pageSize int, status *string) ([]*Task, error) {
+func (m *MockTaskRepository) Get(ctx context.Context, offset, pageSize int, status, searchWord *string) ([]*Task, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", ctx, offset, pageSize, status)
+	ret := m.ctrl.Call(m, "Get", ctx, offset, pageSize, status, searchWord)
 	ret0, _ := ret[0].([]*Task)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockTaskRepositoryMockRecorder) Get(ctx, offset, pageSize, status any) *gomock.Call {
+func (mr *MockTaskRepositoryMockRecorder) Get(ctx, offset, pageSize, status, searchWord any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTaskRepository)(nil).Get), ctx, offset, pageSize, status)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTaskRepository)(nil).Get), ctx, offset, pageSize, status, searchWord)
 }
 
 // Save mocks base method.

--- a/api/src/domain/task/task_repository.go
+++ b/api/src/domain/task/task_repository.go
@@ -6,7 +6,7 @@ import (
 
 type TaskRepository interface {
 	Create(ctx context.Context, task *Task) error
-	Get(ctx context.Context, offset int, pageSize int, status *string) ([]*Task, error)
+	Get(ctx context.Context, offset int, pageSize int, status, searchWord *string) ([]*Task, error)
 	Save(ctx context.Context, task *Task) error
 	FindById(ctx context.Context, id string) (*Task, error)
 }

--- a/api/src/pkg/utils/normalize.go
+++ b/api/src/pkg/utils/normalize.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	"strings"
+
+	"golang.org/x/text/width"
+)
+
+func NormalizeString(str string) string {
+	return width.Narrow.String(strings.ToLower(str))
+}

--- a/api/src/presentation/task/handler.go
+++ b/api/src/presentation/task/handler.go
@@ -1,12 +1,14 @@
 package task
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/shinya-ac/TodoAPI/application/task"
 	"github.com/shinya-ac/TodoAPI/pkg/logging"
+	"github.com/shinya-ac/TodoAPI/pkg/utils"
 	validator "github.com/shinya-ac/TodoAPI/pkg/validator"
 	"github.com/shinya-ac/TodoAPI/presentation/settings"
 )
@@ -89,6 +91,7 @@ func (h handler) GetTasks(ctx *gin.Context) {
 	page := 1
 	pageSize := 100
 	var status *string
+	var searchWord *string
 
 	if p := ctx.Query("page"); p != "" {
 		page, _ = strconv.Atoi(p)
@@ -106,13 +109,18 @@ func (h handler) GetTasks(ctx *gin.Context) {
 			return
 		}
 	}
+	if sw := ctx.Query("searchWord"); sw != "" {
+		normalizedSearchWord := fmt.Sprintf("%%%s%%", utils.NormalizeString(sw))
+		searchWord = &normalizedSearchWord
+	}
 
 	offset := (page - 1) * pageSize
 
 	input := task.GetTaskUseCaseInputDto{
-		Offset:   offset,
-		PageSize: pageSize,
-		Status:   status,
+		Offset:     offset,
+		PageSize:   pageSize,
+		Status:     status,
+		SearchWord: searchWord,
 	}
 
 	dto, err := h.getTaskUseCase.Run(ctx, input)


### PR DESCRIPTION
### タイトルとTodo説明からの文字列検索機能追加

- `searchWord`というクエリパラメーターを取得
- TitleカラムとContentカラムからその文字列に当てはまるTodoレコードを取得
- 他のパラメーター条件（status）とはアンド条件で検索

上記の改修に伴ったテストコードも修正